### PR TITLE
correct command line for updating git core editor: VS Code

### DIFF
--- a/tools/github_tutorial.md
+++ b/tools/github_tutorial.md
@@ -163,13 +163,13 @@ for Mac after configuring Windows.
             
             ![img](https://code.visualstudio.com/assets/docs/setup/mac/shell-command.png "img")
             
-            1.  Restart the terminal for the new $PATH value to take effect.
+            3.  Restart the terminal for the new $PATH value to take effect.
                 You'll be able to type `code .` in any folder to start
                 editing files in that folder.
         
         3.  Setup for git commit messages in the terminal:
             
-            $ git config &#x2013;global core.editor "code &#x2013;wait"
+            $ git config --global core.editor "code --wait"
         
         4.  After this check, check your settings:
             


### PR DESCRIPTION
This PR is to correct the command line for setting up git core editor to be VS Code.

The command line in the original [github_tutorial_mac.md](https://github.com/sjsrey/pbpl204s19/blob/master/tools/github_tutorial_mac.md) is correct:
```bash 
git config --global core.editor "code --wait"
```
The version in [github_tutorial.md](https://github.com/sjsrey/pbpl204s19/blob/master/tools/github_tutorial.md) becomes 
```bash 
$ git config &#x2013;global core.editor "code &#x2013;wait"
```

Not sure why. Probably related to copy and past.
